### PR TITLE
Refactor output paths and adjust equilibration default

### DIFF
--- a/equilibrator/flat/equilibration.mdp
+++ b/equilibrator/flat/equilibration.mdp
@@ -1,6 +1,6 @@
 ; Run parameters
 integrator               = md
-nsteps                   = 5000000     ; 10000 ps with a 2 fs timestep
+nsteps                   = 500000     ; 10000 ps with a 2 fs timestep
 dt                       = 0.002     ; 2 fs
 
 ; Output control

--- a/equilibrator/flat/equilibration_2.mdp
+++ b/equilibrator/flat/equilibration_2.mdp
@@ -1,6 +1,6 @@
 ; Run parameters
 integrator               = md
-nsteps                   = 5000000     ; 10000 ps with a 2 fs timestep
+nsteps                   = 500000     ; 10000 ps with a 2 fs timestep
 dt                       = 0.002       ; 2 fs
 
 ; Output control


### PR DESCRIPTION
-Updated ACPYPE and grompp outputs to be written inside the designated output directory
-Reduced the number of equilibration steps from 5 million to 500,000 (nsteps = 500000)